### PR TITLE
Bathygrid 1.3.3 - 

### DIFF
--- a/bathygrid/__version__.py
+++ b/bathygrid/__version__.py
@@ -1,2 +1,2 @@
-VERSION = (1, 3, 2)
+VERSION = (1, 3, 3)
 __version__ = '.'.join(map(str, VERSION))

--- a/bathygrid/backends.py
+++ b/bathygrid/backends.py
@@ -543,10 +543,10 @@ class ZarrGrid(BaseStorage):
     def _save_array(self, arr_path: str, arr: np.ndarray):
         remove_with_permissionserror(arr_path)
         data = self._zarrgrid_todask(arr)
-        if isinstance(data, str):
-            if data != 'empty':
+        if isinstance(data, str) or (isinstance(data, da.Array) and data.size == 0):
+            if isinstance(data, str) and data != 'empty':
                 raise ValueError(f'Bathygrid zarr backend received str data for "empty" workflow, but str was {data}')
-            os.makedirs(arr_path)
+            os.makedirs(arr_path, exist_ok=True)
             open(os.path.join(arr_path, 'zarr_backend_empty'), 'wb').close()
         else:
             da.to_zarr(data, arr_path)

--- a/bathygrid/bgrid.py
+++ b/bathygrid/bgrid.py
@@ -1419,7 +1419,8 @@ class BathyGrid(BaseGrid):
         grid_parameters
             optional dict of settings to pass to the grid algorithm
         border_data
-            point data that falls on the borders, used in the CUBE algorithm to handle tile edge issues
+            point data that falls on the borders, used in the CUBE algorithm to handle tile edge issues.  You won't supply it here,
+            this argument will be used during VR gridding, with grids passing subgrids the border data automatically.
         """
 
         if self.grid_algorithm and (self.grid_algorithm != algorithm) and not clear_existing:

--- a/bathygrid/bgrid.py
+++ b/bathygrid/bgrid.py
@@ -270,8 +270,11 @@ class BathyGrid(BaseGrid):
 
     @property
     def positive_up(self):
-        if self.vertical_reference.find('height (h)",up') > -1:
-            return True
+        if self.vertical_reference:
+            if self.vertical_reference.find('height (h)",up') > -1:
+                return True
+            else:
+                return False
         return False
 
     def get_geotransform(self, resolution: float):
@@ -1072,9 +1075,9 @@ class BathyGrid(BaseGrid):
         for cnt, tile in enumerate(self.tiles.flat):
             if tile:
                 row, col = self._tile_idx_to_row_col(cnt)
-                tile, data, geo, data_col, data_row, tile_cell_count = self.get_tile_data(row, col, resolution, layer, nodatavalue, z_positive_up)
-                for cnt, lyr in enumerate(data.keys()):
-                    data[cnt][data_col:data_col + tile_cell_count, data_row:data_row + tile_cell_count] = data[lyr]
+                tile, newdata, geo, data_col, data_row, tile_cell_count = self.get_tile_data(row, col, resolution, layer, nodatavalue, z_positive_up)
+                for cnt, lyr in enumerate(newdata.keys()):
+                    data[cnt][data_col:data_col + tile_cell_count, data_row:data_row + tile_cell_count] = newdata[lyr]
                     empty = False
         if empty:
             data = None

--- a/bathygrid/bgrid.py
+++ b/bathygrid/bgrid.py
@@ -964,6 +964,23 @@ class BathyGrid(BaseGrid):
         return finaldata
 
     def _split_to_approx_shape(self, arr: np.ndarray, chunk_shape: tuple):
+        """
+        Take a 2d array and split it up into chunk_shape sized chunks.  We then return the != None values in the array
+        to get the list of lists of values.
+
+        Parameters
+        ----------
+        arr
+            2d array
+        chunk_shape
+            size of the desired chunk, (row_dimension, column_dimension)
+
+        Returns
+        -------
+        list
+            list of lists of the values in each non-None cell
+        """
+
         if arr.ndim != 2 or len(chunk_shape) != 2:
             raise NotImplementedError('_split_to_approx_shape: assumes two dimensions')
 
@@ -987,19 +1004,25 @@ class BathyGrid(BaseGrid):
                     chnks.append(split_b[valid].tolist())
         return chnks
 
-    def _tile_chunk_indices(self, maximum_chunk_dimension: float = None):
+    def _tile_chunk_indices(self, max_chunk_dimension: float = None):
         """
-        
+        In order to return chunks of tiles in get_chunks_of_tiles, we need to figure out the tile indices of the tiles
+        that are in each chunk.  We take a max chunk dimension, split our grid into chunks of grids, and return a list of
+        the row,column indices for each real tile in that grid.
+
         Parameters
         ----------
-        maximum_chunk_dimension
+        max_chunk_dimension
+            size of the chunk, used for both dimensions, i.e. maxchunkdimension=2, chunk shape = (2,2)
 
         Returns
         -------
-
+        list
+            list of lists of row column indices for each real tile in each chunk
         """
-        # ensure we get at least one tile, but pick the number of tiles that gets us less than or equal to maximum_chunk_dimension
-        max_length = max(int(np.floor(maximum_chunk_dimension / self.tile_size)), 1)
+
+        # ensure we get at least one tile, but pick the number of tiles that gets us less than or equal to max_chunk_dimension
+        max_length = max(int(np.floor(max_chunk_dimension / self.tile_size)), 1)
         chunk_shape = (max_length, max_length)
 
         tindex = np.full_like(self.tiles, None)

--- a/bathygrid/bgrid.py
+++ b/bathygrid/bgrid.py
@@ -1267,12 +1267,9 @@ class BathyGrid(BaseGrid):
                 elif isinstance(tile, SRTile) and auto_resolution and self.name not in sr_grid_root_names:  # tiles in vrgridtile can be different resolutions
                     rez = tile.grid(algorithm, None, auto_resolution_mode=auto_resolution, clear_existing=clear_existing, regrid_option=regrid_option, progress_bar=False,
                                     grid_parameters=self.grid_parameters, border_data=border_data)
-                elif isinstance(tile, Tile):  # make sure that the tile gets the border_data
-                    rez = tile.grid(algorithm, resolution, auto_resolution_mode=auto_resolution, clear_existing=clear_existing, regrid_option=regrid_option, progress_bar=False,
-                                    grid_parameters=self.grid_parameters, border_data=border_data)
                 else:
                     rez = tile.grid(algorithm, resolution, auto_resolution_mode=auto_resolution, clear_existing=clear_existing, regrid_option=regrid_option, progress_bar=False,
-                                    grid_parameters=self.grid_parameters)
+                                    grid_parameters=self.grid_parameters, border_data=border_data)
                 if isinstance(rez, float) or isinstance(rez, int):
                     rez = [rez]
                 for rz in rez:
@@ -1864,12 +1861,9 @@ def _gridding_parallel(data_blob: list):
     elif isinstance(tile, SRTile) and auto_resolution and grid_name not in sr_grid_root_names:  # tiles in vrgridtile can be different resolutions
         rez = tile.grid(algorithm, None, auto_resolution_mode=auto_resolution, clear_existing=clear_existing, regrid_option=regrid_option, progress_bar=False,
                         grid_parameters=grid_parameters, border_data=border_data)
-    elif isinstance(tile, Tile):  # make sure that the tile gets the border_data
-        rez = tile.grid(algorithm, resolution, auto_resolution_mode=auto_resolution, clear_existing=clear_existing, regrid_option=regrid_option, progress_bar=False,
-                        grid_parameters=grid_parameters, border_data=border_data)
     else:
         rez = tile.grid(algorithm, resolution, auto_resolution_mode=auto_resolution, clear_existing=clear_existing, regrid_option=regrid_option, progress_bar=False,
-                        grid_parameters=grid_parameters)
+                        grid_parameters=grid_parameters, border_data=border_data)
     return rez, tile
 
 

--- a/bathygrid/bgrid.py
+++ b/bathygrid/bgrid.py
@@ -719,11 +719,6 @@ class BathyGrid(BaseGrid):
             if True, will output bands with positive up convention
         """
 
-        if self.positive_up:
-            if z_positive_up:  # this is already positive up/height, so switch this off
-                z_positive_up = False
-            else:  # this is a positive up/height, so switch this on to flip the z convention of the returned data
-                z_positive_up = True
         if not resolution:
             if len(self.resolutions) > 1:
                 raise ValueError(
@@ -744,6 +739,8 @@ class BathyGrid(BaseGrid):
         """
         Get the data and relevant information for the tile at the provided row/column number.  If the tile is a subgrid
         (vr grids have grids as tiles), this will return the data for that subgrid.
+
+        You should use this method to access a tile, will also allow you to alter the z sign convention.
 
         Parameters
         ----------
@@ -777,6 +774,12 @@ class BathyGrid(BaseGrid):
         int
             width of the tile in number of cells
         """
+
+        if self.positive_up:
+            if z_positive_up:  # this is already positive up/height, so switch this off
+                z_positive_up = False
+            else:  # this is a positive up/height, so switch this on to flip the z convention of the returned data
+                z_positive_up = True
 
         tile = self.tiles[row_number, column_number]
         tile_cell_count = self.tile_size / resolution
@@ -1122,12 +1125,6 @@ class BathyGrid(BaseGrid):
         # ensure nodatavalue is a float32
         nodatavalue = np.float32(nodatavalue)
         empty = True
-        if self.positive_up:
-            if z_positive_up:  # this is already positive up/height, so switch this off
-                z_positive_up = False
-            else:  # this is a positive up/height, so switch this on to flip the z convention of the returned data
-                z_positive_up = True
-
         if isinstance(layer, str):
             layer = [layer]
         if self.no_grid:

--- a/bathygrid/grids.py
+++ b/bathygrid/grids.py
@@ -67,6 +67,30 @@ class BaseGrid(Grid):
                 point_count += tile.points_count
         return point_count
 
+    @property
+    def unique_container_entries(self):
+        """
+        Get the unique container entries, assuming you are using Kluster to add points.  Kluster takes a container name
+        like 'EM2040_123_05_23_2017' and adds the data to the bathygrid in chunks that look like EM2040_123_05_23_2017_0,
+        EM2040_123_05_23_2017_1, etc.  Here we just return one 'EM2040_123_05_23_2017' for all chunks, so that you are left
+        with just the unique container entries.
+        """
+        uentry = []
+        for ky in list(self.container.keys()):
+            try:
+                trailing_underscore = ky[::-1].find('_')
+                if trailing_underscore == -1:
+                    raise ValueError  # not a tagged entry, just do the normal append
+                for kchar in ky[-trailing_underscore:]:  # tagged entry should only have integers after the last underscore
+                    int(kchar)  # otherwise just do the normal append (you get a ValueError here)
+                new_uentry = ky[:-trailing_underscore - 1]
+                if new_uentry not in uentry:
+                    uentry.append(new_uentry)
+            except ValueError:
+                if ky not in uentry:
+                    uentry.append(ky)
+        return uentry
+
     def _adjust_extents(self):
         """
         If this BathyGrid is allowed to grow, we extend the boundaries by integer increments of tile_size

--- a/bathygrid/utilities.py
+++ b/bathygrid/utilities.py
@@ -90,8 +90,11 @@ def create_folder(output_directory: str, fldrname: str):
         fldr_path = os.path.join(output_directory, fldrname)
         os.mkdir(fldr_path)
     except FileExistsError:
-        fldr_path = os.path.join(output_directory, fldrname + '_{}'.format(tstmp))
-        os.mkdir(fldr_path)
+        if not os.listdir(os.path.join(output_directory, fldrname)):  # if the folder is empty, we can still use it
+            fldr_path = os.path.join(output_directory, fldrname)
+        else:
+            fldr_path = os.path.join(output_directory, fldrname + '_{}'.format(tstmp))
+            os.mkdir(fldr_path)
     return fldr_path
 
 

--- a/tests/test_bgrid.py
+++ b/tests/test_bgrid.py
@@ -611,8 +611,8 @@ def test_get_chunks_of_tiles():
         testfinalgeo.append(geo)
         testfinalmaxdim.append(max_dimension)
     assert testfinalmaxdim[0] == 2048.0
-    assert testfinalgeo[0] == [0.0, 64.0, 0, 50176.0, 0, -64.0]
-    assert testfinaldata[0]['depth'].shape == (32, 16)
+    assert testfinalgeo[0] == [0.0, 64.0, 0, 51200.0, 0, -64.0]
+    assert testfinaldata[0]['depth'].shape == (32, 32)
 
     bg = VRGridTile(tile_size=1024, subtile_size=128)
     bg.add_points(smalldata2, 'test1', ['line1', 'line2'], 26917, 'waterline')
@@ -637,8 +637,8 @@ def test_get_chunks_of_tiles():
         testfinalgeo.append(geo)
         testfinalmaxdim.append(max_dimension)
     assert testfinalmaxdim[0] == 2048.0
-    assert testfinalgeo[0] == [0.0, 64.0, 0, 50176.0, 0, -64.0]
-    assert testfinaldata[0]['depth'].shape == (32, 16)
+    assert testfinalgeo[0] == [0.0, 64.0, 0, 51200.0, 0, -64.0]
+    assert testfinaldata[0]['depth'].shape == (32, 32)
 
 
 def test_layer_values_at_xy():


### PR DESCRIPTION
include bordering soundings from nearby grids with vr grid
new export/drawing tile scheme in get_chunks_of_tiles, gets nice square tiles with adjustable size
expose override_chunk_dimension for drawing/exporting in kluster

z positive up flag will now operate knowing the underlying sign convention
resolve bug with saving empty dask arrays to zarr
